### PR TITLE
docs: Cursor Cloud setup + baseline D1 migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Product layout
+
+- **Backend** (`assets-management-backend/`): Next.js 16 + GraphQL Yoga at `/api/graphql`, Drizzle ORM on Cloudflare D1 (`team_one`). Also serves a simple **Excel import** UI at `/`.
+- **Frontend** (`assets-management-frontend/Dashboard-frontend/`): Next.js dashboard (AssetHub) on a separate port; talks to the backend via `NEXT_PUBLIC_GRAPHQL_URL`.
+
+See each app's `package.json` for `dev`, `build`, `lint`, `preview`, and `deploy` scripts.
+
+### Local development (no Cloudflare login)
+
+Committed `wrangler.jsonc` sets D1/KV bindings to `"remote": true`, which makes `next dev` proxy to Cloudflare and fail without `wrangler login`. For local work, use **local bindings** (set `"remote": false` on D1/KV in `wrangler.jsonc`, or maintain a local-only copy) before starting the backend.
+
+Initialize the local D1 schema:
+
+```bash
+cd assets-management-backend
+# If `wrangler d1 migrations apply team_one --local` fails with "no such table: assets", generate the baseline migration once:
+npx drizzle-kit generate --name init_schema
+npx wrangler d1 migrations apply team_one --local
+```
+
+If migration `0001_add_current_book_value.sql` fails with "duplicate column", the init migration already includes `currentBookValue`; local DB is still usable.
+
+### Running both apps
+
+Both default to port **3000**. Typical layout:
+
+| Service  | Directory | Command |
+|----------|-----------|---------|
+| Backend  | `assets-management-backend` | `DISABLE_AUTH=1 npm run dev` |
+| Frontend | `assets-management-frontend/Dashboard-frontend` | `PORT=3001 npm run dev` |
+
+Frontend env (minimum without Clerk):
+
+- `NEXT_PUBLIC_GRAPHQL_URL=http://localhost:3000/api/graphql`
+- `NEXT_PUBLIC_DISABLE_AUTH=1`
+
+**Clerk is required** for the dashboard: valid `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (and related Clerk URLs). Without them, `next dev` / `next build` fail in `ClerkProvider`. Backend can run with `DISABLE_AUTH=1` only.
+
+### Lint / test
+
+- No automated test scripts in either `package.json`.
+- `npm run lint` currently errors on Next.js 16 (`next lint` treats `lint` as a directory). Use `npx eslint .` in each app directory instead (existing configs have many pre-existing violations).
+
+### Quick API smoke test
+
+```bash
+curl -s http://localhost:3000/api/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ employees { id } assets { id assetTag } }"}'
+```
+
+With `DISABLE_AUTH=1`, you can run `createEmployee` / `createAsset` mutations without a Bearer token.
+
+### Optional services
+
+R2 (uploads), Resend (email), and remote D1/KV are optional for core CRUD; see backend `wrangler.jsonc` and GraphQL resolvers.

--- a/assets-management-backend/drizzle/0000_init_schema.sql
+++ b/assets-management-backend/drizzle/0000_init_schema.sql
@@ -1,0 +1,511 @@
+CREATE TABLE `asset_contracts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetId` text NOT NULL,
+	`type` text NOT NULL,
+	`vendorId` text,
+	`startDate` integer NOT NULL,
+	`endDate` integer NOT NULL,
+	`notes` text,
+	`documentKey` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`vendorId`) REFERENCES `vendors`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `asset_contracts_asset_idx` ON `asset_contracts` (`assetId`);--> statement-breakpoint
+CREATE INDEX `asset_contracts_end_date_idx` ON `asset_contracts` (`endDate`);--> statement-breakpoint
+CREATE TABLE `asset_files` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetId` text NOT NULL,
+	`type` text NOT NULL,
+	`fileKey` text NOT NULL,
+	`uploadedBy` text NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`uploadedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `asset_models` (
+	`id` text PRIMARY KEY NOT NULL,
+	`categoryId` text NOT NULL,
+	`manufacturer` text NOT NULL,
+	`modelName` text NOT NULL,
+	`modelNumber` text,
+	`expectedLifeMonths` integer,
+	`depreciationRate` numeric,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`categoryId`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `asset_models_category_idx` ON `asset_models` (`categoryId`);--> statement-breakpoint
+CREATE TABLE `asset_movements` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetId` text NOT NULL,
+	`fromLocationId` text NOT NULL,
+	`toLocationId` text NOT NULL,
+	`movedBy` text NOT NULL,
+	`reason` text,
+	`movedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`fromLocationId`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`toLocationId`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`movedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `asset_movements_asset_idx` ON `asset_movements` (`assetId`);--> statement-breakpoint
+CREATE INDEX `asset_movements_to_location_idx` ON `asset_movements` (`toLocationId`);--> statement-breakpoint
+CREATE TABLE `assets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetTag` text NOT NULL,
+	`serialNumber` text NOT NULL,
+	`modelId` text,
+	`mainCategoryId` text,
+	`categoryId` text,
+	`status` text DEFAULT 'AVAILABLE' NOT NULL,
+	`purchaseDate` integer,
+	`purchaseCost` integer,
+	`currentBookValue` integer,
+	`locationId` text,
+	`imageUrl` text,
+	`notes` text,
+	`condition` text DEFAULT 'GOOD' NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`deletedAt` integer,
+	FOREIGN KEY (`modelId`) REFERENCES `asset_models`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`mainCategoryId`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`categoryId`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`locationId`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `assets_status_idx` ON `assets` (`status`);--> statement-breakpoint
+CREATE INDEX `assets_main_category_idx` ON `assets` (`mainCategoryId`);--> statement-breakpoint
+CREATE INDEX `assets_category_idx` ON `assets` (`categoryId`);--> statement-breakpoint
+CREATE INDEX `assets_model_idx` ON `assets` (`modelId`);--> statement-breakpoint
+CREATE INDEX `assets_location_idx` ON `assets` (`locationId`);--> statement-breakpoint
+CREATE INDEX `assets_filter_idx` ON `assets` (`status`,`categoryId`,`locationId`);--> statement-breakpoint
+CREATE INDEX `assets_created_at_idx` ON `assets` (`createdAt`);--> statement-breakpoint
+CREATE INDEX `assets_deleted_at_idx` ON `assets` (`deletedAt`);--> statement-breakpoint
+CREATE INDEX `assets_asset_tag_idx` ON `assets` (`assetTag`);--> statement-breakpoint
+CREATE INDEX `assets_serial_number_idx` ON `assets` (`serialNumber`);--> statement-breakpoint
+CREATE TABLE `assignment_buyout_policies` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`minEmploymentMonths` integer NOT NULL,
+	`paymentPercent` numeric NOT NULL,
+	`isFree` integer DEFAULT 0 NOT NULL,
+	`categoryId` text,
+	`isDefault` integer DEFAULT 0 NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`categoryId`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `buyout_category_idx` ON `assignment_buyout_policies` (`categoryId`);--> statement-breakpoint
+CREATE TABLE `assignment_financing` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assignmentId` text NOT NULL,
+	`assignedValue` integer,
+	`paymentPlanMonths` integer,
+	`interestRate` numeric,
+	`monthlyPayment` integer,
+	`totalPayment` integer,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`assignmentId`) REFERENCES `assignments`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `financing_assignment_idx` ON `assignment_financing` (`assignmentId`);--> statement-breakpoint
+CREATE TABLE `assignment_payments` (
+	`id` text PRIMARY KEY NOT NULL,
+	`financingId` text NOT NULL,
+	`amount` integer NOT NULL,
+	`dueDate` integer NOT NULL,
+	`paidAt` integer,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`financingId`) REFERENCES `assignment_financing`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `payment_financing_idx` ON `assignment_payments` (`financingId`);--> statement-breakpoint
+CREATE INDEX `payment_status_idx` ON `assignment_payments` (`status`);--> statement-breakpoint
+CREATE TABLE `assignments` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetId` text NOT NULL,
+	`employeeId` text NOT NULL,
+	`assignedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`returnedAt` integer,
+	`conditionAtAssign` text NOT NULL,
+	`conditionAtReturn` text,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`signatureR2Key` text,
+	`accessoriesJson` text,
+	`buyoutPolicyId` text,
+	`requestedByEmployeeId` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`deletedAt` integer,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`buyoutPolicyId`) REFERENCES `assignment_buyout_policies`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`requestedByEmployeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `assignments_asset_idx` ON `assignments` (`assetId`);--> statement-breakpoint
+CREATE INDEX `assignments_employee_idx` ON `assignments` (`employeeId`);--> statement-breakpoint
+CREATE INDEX `assignments_status_idx` ON `assignments` (`status`);--> statement-breakpoint
+CREATE TABLE `audit_logs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tableName` text NOT NULL,
+	`recordId` text NOT NULL,
+	`action` text NOT NULL,
+	`oldValueJson` text,
+	`newValueJson` text,
+	`actorId` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`actorId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `audit_logs_table_name_idx` ON `audit_logs` (`tableName`);--> statement-breakpoint
+CREATE INDEX `audit_logs_record_id_idx` ON `audit_logs` (`recordId`);--> statement-breakpoint
+CREATE INDEX `audit_logs_actor_id_idx` ON `audit_logs` (`actorId`);--> statement-breakpoint
+CREATE TABLE `categories` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`parentId` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`parentId`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `census_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`scope` text NOT NULL,
+	`scopeFilter` text,
+	`createdBy` text NOT NULL,
+	`startedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`closedAt` integer,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`createdBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `census_events_closed_at_idx` ON `census_events` (`closedAt`);--> statement-breakpoint
+CREATE TABLE `census_tasks` (
+	`id` text PRIMARY KEY NOT NULL,
+	`censusId` text NOT NULL,
+	`assetId` text NOT NULL,
+	`verifierId` text,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`reason` text,
+	`transferredToEmployeeId` text,
+	`respondedAt` integer,
+	`conditionReported` text,
+	`locationConfirmed` text,
+	`discrepancyFlag` integer DEFAULT 0 NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`censusId`) REFERENCES `census_events`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`verifierId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`transferredToEmployeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `census_tasks_asset_id_idx` ON `census_tasks` (`assetId`);--> statement-breakpoint
+CREATE INDEX `census_tasks_census_id_idx` ON `census_tasks` (`censusId`);--> statement-breakpoint
+CREATE INDEX `census_tasks_verifier_id_idx` ON `census_tasks` (`verifierId`);--> statement-breakpoint
+CREATE INDEX `census_tasks_status_value_idx` ON `census_tasks` (`status`);--> statement-breakpoint
+CREATE TABLE `data_wipe_tasks` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetId` text NOT NULL,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `data_wipe_tasks_asset_idx` ON `data_wipe_tasks` (`assetId`);--> statement-breakpoint
+CREATE INDEX `data_wipe_tasks_status_idx` ON `data_wipe_tasks` (`status`);--> statement-breakpoint
+CREATE TABLE `disposal_records` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetId` text NOT NULL,
+	`method` text NOT NULL,
+	`writeOffValue` integer,
+	`certifiedBy` text NOT NULL,
+	`certR2Key` text,
+	`recipient` text,
+	`disposedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`certifiedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `disposal_records_asset_idx` ON `disposal_records` (`assetId`);--> statement-breakpoint
+CREATE TABLE `disposal_requests` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetId` text NOT NULL,
+	`requestedBy` text NOT NULL,
+	`method` text NOT NULL,
+	`reason` text,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`itApprovedBy` text,
+	`itApprovedAt` integer,
+	`financeApprovedBy` text,
+	`financeApprovedAt` integer,
+	`dataWipeCertKey` text,
+	`rejectedBy` text,
+	`rejectedAt` integer,
+	`rejectionReason` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`requestedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`itApprovedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`financeApprovedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`rejectedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `disposal_requests_asset_idx` ON `disposal_requests` (`assetId`);--> statement-breakpoint
+CREATE INDEX `disposal_requests_status_idx` ON `disposal_requests` (`status`);--> statement-breakpoint
+CREATE TABLE `employee_notifications` (
+	`id` text PRIMARY KEY NOT NULL,
+	`employeeId` text NOT NULL,
+	`title` text NOT NULL,
+	`message` text NOT NULL,
+	`type` text DEFAULT 'INFO' NOT NULL,
+	`link` text,
+	`isRead` integer DEFAULT 0 NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `emp_notif_employee_idx` ON `employee_notifications` (`employeeId`);--> statement-breakpoint
+CREATE INDEX `emp_notif_read_idx` ON `employee_notifications` (`employeeId`,`isRead`);--> statement-breakpoint
+CREATE TABLE `employees` (
+	`id` text PRIMARY KEY NOT NULL,
+	`entraId` text,
+	`clerkId` text,
+	`role` text DEFAULT 'EMPLOYEE' NOT NULL,
+	`firstName` text NOT NULL,
+	`lastName` text NOT NULL,
+	`firstNameEng` text NOT NULL,
+	`lastNameEng` text NOT NULL,
+	`email` text NOT NULL,
+	`imageUrl` text,
+	`signUrl` text,
+	`hireDate` integer NOT NULL,
+	`terminationDate` integer,
+	`status` text DEFAULT 'INACTIVE' NOT NULL,
+	`numberOfVacationDays` integer,
+	`github` text,
+	`department` text NOT NULL,
+	`branch` text NOT NULL,
+	`employeeCode` text NOT NULL,
+	`level` text NOT NULL,
+	`isKpi` integer DEFAULT 0 NOT NULL,
+	`isSalaryCompany` integer DEFAULT 1 NOT NULL,
+	`birthDayAndMonth` text,
+	`birthdayPoster` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`deletedAt` integer
+);
+--> statement-breakpoint
+CREATE TABLE `locations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`parentId` text,
+	`type` text NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`parentId`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `maintenance_tickets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetId` text NOT NULL,
+	`reporterId` text NOT NULL,
+	`description` text NOT NULL,
+	`severity` text NOT NULL,
+	`status` text DEFAULT 'OPEN' NOT NULL,
+	`vendorId` text,
+	`repairCost` integer,
+	`slaDeadline` integer,
+	`resolvedAt` integer,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`reporterId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`vendorId`) REFERENCES `vendors`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `maintenance_tickets_asset_idx` ON `maintenance_tickets` (`assetId`);--> statement-breakpoint
+CREATE INDEX `maintenance_tickets_status_idx` ON `maintenance_tickets` (`status`);--> statement-breakpoint
+CREATE INDEX `maintenance_tickets_sla_idx` ON `maintenance_tickets` (`slaDeadline`);--> statement-breakpoint
+CREATE TABLE `notifications` (
+	`id` text PRIMARY KEY NOT NULL,
+	`employeeId` text,
+	`role` text,
+	`title` text NOT NULL,
+	`message` text NOT NULL,
+	`type` text DEFAULT 'INFO' NOT NULL,
+	`link` text,
+	`isRead` integer DEFAULT 0 NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `notifications_employee_idx` ON `notifications` (`employeeId`);--> statement-breakpoint
+CREATE INDEX `notifications_role_idx` ON `notifications` (`role`);--> statement-breakpoint
+CREATE INDEX `notifications_read_idx` ON `notifications` (`isRead`);--> statement-breakpoint
+CREATE TABLE `offboarding_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`employeeId` text NOT NULL,
+	`initiatedBy` text,
+	`status` text DEFAULT 'IN_PROGRESS' NOT NULL,
+	`totalAssets` integer DEFAULT 0 NOT NULL,
+	`returnedAssets` integer DEFAULT 0 NOT NULL,
+	`assetIdsJson` text DEFAULT '[]' NOT NULL,
+	`deadline` integer,
+	`completedAt` integer,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`initiatedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `offboarding_events_employee_id_idx` ON `offboarding_events` (`employeeId`);--> statement-breakpoint
+CREATE INDEX `offboarding_events_status_value_idx` ON `offboarding_events` (`status`);--> statement-breakpoint
+CREATE TABLE `offboarding_return_requests` (
+	`id` text PRIMARY KEY NOT NULL,
+	`offboardingEventId` text NOT NULL,
+	`assetId` text NOT NULL,
+	`assignmentId` text NOT NULL,
+	`employeeId` text NOT NULL,
+	`conditionEmployee` text NOT NULL,
+	`status` text DEFAULT 'PENDING_HR' NOT NULL,
+	`conditionHr` text,
+	`photoR2Key` text,
+	`inspectedBy` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`offboardingEventId`) REFERENCES `offboarding_events`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`assignmentId`) REFERENCES `assignments`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`inspectedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `offboarding_return_requests_event_idx` ON `offboarding_return_requests` (`offboardingEventId`);--> statement-breakpoint
+CREATE INDEX `offboarding_return_requests_asset_idx` ON `offboarding_return_requests` (`assetId`);--> statement-breakpoint
+CREATE INDEX `offboarding_return_requests_status_idx` ON `offboarding_return_requests` (`status`);--> statement-breakpoint
+CREATE TABLE `purchase_order_items` (
+	`id` text PRIMARY KEY NOT NULL,
+	`purchaseOrderId` text NOT NULL,
+	`categoryId` text NOT NULL,
+	`modelId` text,
+	`name` text,
+	`quantity` integer NOT NULL,
+	`unitCost` integer NOT NULL,
+	`totalCost` integer NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`purchaseOrderId`) REFERENCES `purchase_orders`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`categoryId`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`modelId`) REFERENCES `asset_models`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `purchase_order_items_order_idx` ON `purchase_order_items` (`purchaseOrderId`);--> statement-breakpoint
+CREATE TABLE `purchase_orders` (
+	`id` text PRIMARY KEY NOT NULL,
+	`vendorId` text NOT NULL,
+	`requestedBy` text NOT NULL,
+	`approvedBy` text,
+	`totalCost` integer NOT NULL,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`deliveredAt` integer,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`deletedAt` integer,
+	FOREIGN KEY (`vendorId`) REFERENCES `vendors`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`requestedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`approvedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `purchase_orders_vendor_idx` ON `purchase_orders` (`vendorId`);--> statement-breakpoint
+CREATE INDEX `purchase_orders_status_idx` ON `purchase_orders` (`status`);--> statement-breakpoint
+CREATE TABLE `purchase_requests` (
+	`id` text PRIMARY KEY NOT NULL,
+	`categoryId` text NOT NULL,
+	`modelId` text,
+	`assetTag` text NOT NULL,
+	`serialNumber` text NOT NULL,
+	`purchaseCost` integer,
+	`purchaseDate` integer,
+	`requesterEmployeeId` text NOT NULL,
+	`requesterEmail` text NOT NULL,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`token` text NOT NULL,
+	`expiresAt` integer,
+	`decidedAt` integer,
+	`decidedBy` text,
+	`resolvedAssetId` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updatedAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`categoryId`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`modelId`) REFERENCES `asset_models`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`requesterEmployeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`decidedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`resolvedAssetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `purchase_requests_category_idx` ON `purchase_requests` (`categoryId`);--> statement-breakpoint
+CREATE INDEX `purchase_requests_asset_idx` ON `purchase_requests` (`resolvedAssetId`);--> statement-breakpoint
+CREATE TABLE `role_notification_reads` (
+	`id` text PRIMARY KEY NOT NULL,
+	`notificationId` text NOT NULL,
+	`employeeId` text NOT NULL,
+	`readAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`notificationId`) REFERENCES `role_notifications`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `role_notif_reads_notif_idx` ON `role_notification_reads` (`notificationId`);--> statement-breakpoint
+CREATE INDEX `role_notif_reads_emp_idx` ON `role_notification_reads` (`employeeId`);--> statement-breakpoint
+CREATE INDEX `role_notif_reads_unique_idx` ON `role_notification_reads` (`notificationId`,`employeeId`);--> statement-breakpoint
+CREATE TABLE `role_notifications` (
+	`id` text PRIMARY KEY NOT NULL,
+	`role` text NOT NULL,
+	`title` text NOT NULL,
+	`message` text NOT NULL,
+	`type` text DEFAULT 'INFO' NOT NULL,
+	`link` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `role_notif_role_idx` ON `role_notifications` (`role`);--> statement-breakpoint
+CREATE TABLE `transfers` (
+	`id` text PRIMARY KEY NOT NULL,
+	`assetId` text NOT NULL,
+	`fromEmployeeId` text NOT NULL,
+	`toEmployeeId` text NOT NULL,
+	`reason` text,
+	`approvedBy` text,
+	`conditionNoted` text,
+	`transferredAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`assetId`) REFERENCES `assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`fromEmployeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`toEmployeeId`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`approvedBy`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `transfers_asset_idx` ON `transfers` (`assetId`);--> statement-breakpoint
+CREATE INDEX `transfers_from_employee_idx` ON `transfers` (`fromEmployeeId`);--> statement-breakpoint
+CREATE INDEX `transfers_to_employee_idx` ON `transfers` (`toEmployeeId`);--> statement-breakpoint
+CREATE TABLE `vendors` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`contactName` text,
+	`email` text,
+	`phone` text,
+	`address` text,
+	`createdAt` integer DEFAULT (unixepoch() * 1000) NOT NULL
+);

--- a/assets-management-backend/drizzle/meta/0000_snapshot.json
+++ b/assets-management-backend/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,3792 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6d429db4-41f3-418e-979c-ee01baacc99c",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "asset_contracts": {
+      "name": "asset_contracts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vendorId": {
+          "name": "vendorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "documentKey": {
+          "name": "documentKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "asset_contracts_asset_idx": {
+          "name": "asset_contracts_asset_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        },
+        "asset_contracts_end_date_idx": {
+          "name": "asset_contracts_end_date_idx",
+          "columns": [
+            "endDate"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "asset_contracts_assetId_assets_id_fk": {
+          "name": "asset_contracts_assetId_assets_id_fk",
+          "tableFrom": "asset_contracts",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "asset_contracts_vendorId_vendors_id_fk": {
+          "name": "asset_contracts_vendorId_vendors_id_fk",
+          "tableFrom": "asset_contracts",
+          "tableTo": "vendors",
+          "columnsFrom": [
+            "vendorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "asset_files": {
+      "name": "asset_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fileKey": {
+          "name": "fileKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploadedBy": {
+          "name": "uploadedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_files_assetId_assets_id_fk": {
+          "name": "asset_files_assetId_assets_id_fk",
+          "tableFrom": "asset_files",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "asset_files_uploadedBy_employees_id_fk": {
+          "name": "asset_files_uploadedBy_employees_id_fk",
+          "tableFrom": "asset_files",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "uploadedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "asset_models": {
+      "name": "asset_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelName": {
+          "name": "modelName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelNumber": {
+          "name": "modelNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expectedLifeMonths": {
+          "name": "expectedLifeMonths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "depreciationRate": {
+          "name": "depreciationRate",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "asset_models_category_idx": {
+          "name": "asset_models_category_idx",
+          "columns": [
+            "categoryId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "asset_models_categoryId_categories_id_fk": {
+          "name": "asset_models_categoryId_categories_id_fk",
+          "tableFrom": "asset_models",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "categoryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "asset_movements": {
+      "name": "asset_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fromLocationId": {
+          "name": "fromLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toLocationId": {
+          "name": "toLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movedBy": {
+          "name": "movedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "movedAt": {
+          "name": "movedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "asset_movements_asset_idx": {
+          "name": "asset_movements_asset_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        },
+        "asset_movements_to_location_idx": {
+          "name": "asset_movements_to_location_idx",
+          "columns": [
+            "toLocationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "asset_movements_assetId_assets_id_fk": {
+          "name": "asset_movements_assetId_assets_id_fk",
+          "tableFrom": "asset_movements",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "asset_movements_fromLocationId_locations_id_fk": {
+          "name": "asset_movements_fromLocationId_locations_id_fk",
+          "tableFrom": "asset_movements",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "fromLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "asset_movements_toLocationId_locations_id_fk": {
+          "name": "asset_movements_toLocationId_locations_id_fk",
+          "tableFrom": "asset_movements",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "toLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "asset_movements_movedBy_employees_id_fk": {
+          "name": "asset_movements_movedBy_employees_id_fk",
+          "tableFrom": "asset_movements",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "movedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assets": {
+      "name": "assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetTag": {
+          "name": "assetTag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "serialNumber": {
+          "name": "serialNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mainCategoryId": {
+          "name": "mainCategoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'AVAILABLE'"
+        },
+        "purchaseDate": {
+          "name": "purchaseDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchaseCost": {
+          "name": "purchaseCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currentBookValue": {
+          "name": "currentBookValue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'GOOD'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assets_status_idx": {
+          "name": "assets_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "assets_main_category_idx": {
+          "name": "assets_main_category_idx",
+          "columns": [
+            "mainCategoryId"
+          ],
+          "isUnique": false
+        },
+        "assets_category_idx": {
+          "name": "assets_category_idx",
+          "columns": [
+            "categoryId"
+          ],
+          "isUnique": false
+        },
+        "assets_model_idx": {
+          "name": "assets_model_idx",
+          "columns": [
+            "modelId"
+          ],
+          "isUnique": false
+        },
+        "assets_location_idx": {
+          "name": "assets_location_idx",
+          "columns": [
+            "locationId"
+          ],
+          "isUnique": false
+        },
+        "assets_filter_idx": {
+          "name": "assets_filter_idx",
+          "columns": [
+            "status",
+            "categoryId",
+            "locationId"
+          ],
+          "isUnique": false
+        },
+        "assets_created_at_idx": {
+          "name": "assets_created_at_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "assets_deleted_at_idx": {
+          "name": "assets_deleted_at_idx",
+          "columns": [
+            "deletedAt"
+          ],
+          "isUnique": false
+        },
+        "assets_asset_tag_idx": {
+          "name": "assets_asset_tag_idx",
+          "columns": [
+            "assetTag"
+          ],
+          "isUnique": false
+        },
+        "assets_serial_number_idx": {
+          "name": "assets_serial_number_idx",
+          "columns": [
+            "serialNumber"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assets_modelId_asset_models_id_fk": {
+          "name": "assets_modelId_asset_models_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "asset_models",
+          "columnsFrom": [
+            "modelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_mainCategoryId_categories_id_fk": {
+          "name": "assets_mainCategoryId_categories_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "mainCategoryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_categoryId_categories_id_fk": {
+          "name": "assets_categoryId_categories_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "categoryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_locationId_locations_id_fk": {
+          "name": "assets_locationId_locations_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "locationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assignment_buyout_policies": {
+      "name": "assignment_buyout_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minEmploymentMonths": {
+          "name": "minEmploymentMonths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paymentPercent": {
+          "name": "paymentPercent",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isFree": {
+          "name": "isFree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "buyout_category_idx": {
+          "name": "buyout_category_idx",
+          "columns": [
+            "categoryId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assignment_buyout_policies_categoryId_categories_id_fk": {
+          "name": "assignment_buyout_policies_categoryId_categories_id_fk",
+          "tableFrom": "assignment_buyout_policies",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "categoryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assignment_financing": {
+      "name": "assignment_financing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignmentId": {
+          "name": "assignmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignedValue": {
+          "name": "assignedValue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paymentPlanMonths": {
+          "name": "paymentPlanMonths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interestRate": {
+          "name": "interestRate",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthlyPayment": {
+          "name": "monthlyPayment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totalPayment": {
+          "name": "totalPayment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "financing_assignment_idx": {
+          "name": "financing_assignment_idx",
+          "columns": [
+            "assignmentId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assignment_financing_assignmentId_assignments_id_fk": {
+          "name": "assignment_financing_assignmentId_assignments_id_fk",
+          "tableFrom": "assignment_financing",
+          "tableTo": "assignments",
+          "columnsFrom": [
+            "assignmentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assignment_payments": {
+      "name": "assignment_payments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "financingId": {
+          "name": "financingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paidAt": {
+          "name": "paidAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "payment_financing_idx": {
+          "name": "payment_financing_idx",
+          "columns": [
+            "financingId"
+          ],
+          "isUnique": false
+        },
+        "payment_status_idx": {
+          "name": "payment_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assignment_payments_financingId_assignment_financing_id_fk": {
+          "name": "assignment_payments_financingId_assignment_financing_id_fk",
+          "tableFrom": "assignment_payments",
+          "tableTo": "assignment_financing",
+          "columnsFrom": [
+            "financingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assignments": {
+      "name": "assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "employeeId": {
+          "name": "employeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignedAt": {
+          "name": "assignedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "returnedAt": {
+          "name": "returnedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conditionAtAssign": {
+          "name": "conditionAtAssign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conditionAtReturn": {
+          "name": "conditionAtReturn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "signatureR2Key": {
+          "name": "signatureR2Key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessoriesJson": {
+          "name": "accessoriesJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "buyoutPolicyId": {
+          "name": "buyoutPolicyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requestedByEmployeeId": {
+          "name": "requestedByEmployeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assignments_asset_idx": {
+          "name": "assignments_asset_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        },
+        "assignments_employee_idx": {
+          "name": "assignments_employee_idx",
+          "columns": [
+            "employeeId"
+          ],
+          "isUnique": false
+        },
+        "assignments_status_idx": {
+          "name": "assignments_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assignments_assetId_assets_id_fk": {
+          "name": "assignments_assetId_assets_id_fk",
+          "tableFrom": "assignments",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assignments_employeeId_employees_id_fk": {
+          "name": "assignments_employeeId_employees_id_fk",
+          "tableFrom": "assignments",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assignments_buyoutPolicyId_assignment_buyout_policies_id_fk": {
+          "name": "assignments_buyoutPolicyId_assignment_buyout_policies_id_fk",
+          "tableFrom": "assignments",
+          "tableTo": "assignment_buyout_policies",
+          "columnsFrom": [
+            "buyoutPolicyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assignments_requestedByEmployeeId_employees_id_fk": {
+          "name": "assignments_requestedByEmployeeId_employees_id_fk",
+          "tableFrom": "assignments",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "requestedByEmployeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tableName": {
+          "name": "tableName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recordId": {
+          "name": "recordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oldValueJson": {
+          "name": "oldValueJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "newValueJson": {
+          "name": "newValueJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "audit_logs_table_name_idx": {
+          "name": "audit_logs_table_name_idx",
+          "columns": [
+            "tableName"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_record_id_idx": {
+          "name": "audit_logs_record_id_idx",
+          "columns": [
+            "recordId"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_actor_id_idx": {
+          "name": "audit_logs_actor_id_idx",
+          "columns": [
+            "actorId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_actorId_employees_id_fk": {
+          "name": "audit_logs_actorId_employees_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parentId_categories_id_fk": {
+          "name": "categories_parentId_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "census_events": {
+      "name": "census_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopeFilter": {
+          "name": "scopeFilter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "census_events_closed_at_idx": {
+          "name": "census_events_closed_at_idx",
+          "columns": [
+            "closedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "census_events_createdBy_employees_id_fk": {
+          "name": "census_events_createdBy_employees_id_fk",
+          "tableFrom": "census_events",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "census_tasks": {
+      "name": "census_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "censusId": {
+          "name": "censusId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verifierId": {
+          "name": "verifierId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transferredToEmployeeId": {
+          "name": "transferredToEmployeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conditionReported": {
+          "name": "conditionReported",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationConfirmed": {
+          "name": "locationConfirmed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discrepancyFlag": {
+          "name": "discrepancyFlag",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "census_tasks_asset_id_idx": {
+          "name": "census_tasks_asset_id_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        },
+        "census_tasks_census_id_idx": {
+          "name": "census_tasks_census_id_idx",
+          "columns": [
+            "censusId"
+          ],
+          "isUnique": false
+        },
+        "census_tasks_verifier_id_idx": {
+          "name": "census_tasks_verifier_id_idx",
+          "columns": [
+            "verifierId"
+          ],
+          "isUnique": false
+        },
+        "census_tasks_status_value_idx": {
+          "name": "census_tasks_status_value_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "census_tasks_censusId_census_events_id_fk": {
+          "name": "census_tasks_censusId_census_events_id_fk",
+          "tableFrom": "census_tasks",
+          "tableTo": "census_events",
+          "columnsFrom": [
+            "censusId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "census_tasks_assetId_assets_id_fk": {
+          "name": "census_tasks_assetId_assets_id_fk",
+          "tableFrom": "census_tasks",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "census_tasks_verifierId_employees_id_fk": {
+          "name": "census_tasks_verifierId_employees_id_fk",
+          "tableFrom": "census_tasks",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "verifierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "census_tasks_transferredToEmployeeId_employees_id_fk": {
+          "name": "census_tasks_transferredToEmployeeId_employees_id_fk",
+          "tableFrom": "census_tasks",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "transferredToEmployeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "data_wipe_tasks": {
+      "name": "data_wipe_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "data_wipe_tasks_asset_idx": {
+          "name": "data_wipe_tasks_asset_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        },
+        "data_wipe_tasks_status_idx": {
+          "name": "data_wipe_tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "data_wipe_tasks_assetId_assets_id_fk": {
+          "name": "data_wipe_tasks_assetId_assets_id_fk",
+          "tableFrom": "data_wipe_tasks",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "disposal_records": {
+      "name": "disposal_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "writeOffValue": {
+          "name": "writeOffValue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certifiedBy": {
+          "name": "certifiedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "certR2Key": {
+          "name": "certR2Key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disposedAt": {
+          "name": "disposedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "disposal_records_asset_idx": {
+          "name": "disposal_records_asset_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "disposal_records_assetId_assets_id_fk": {
+          "name": "disposal_records_assetId_assets_id_fk",
+          "tableFrom": "disposal_records",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "disposal_records_certifiedBy_employees_id_fk": {
+          "name": "disposal_records_certifiedBy_employees_id_fk",
+          "tableFrom": "disposal_records",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "certifiedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "disposal_requests": {
+      "name": "disposal_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "itApprovedBy": {
+          "name": "itApprovedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "itApprovedAt": {
+          "name": "itApprovedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "financeApprovedBy": {
+          "name": "financeApprovedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "financeApprovedAt": {
+          "name": "financeApprovedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dataWipeCertKey": {
+          "name": "dataWipeCertKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejectedBy": {
+          "name": "rejectedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejectedAt": {
+          "name": "rejectedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "disposal_requests_asset_idx": {
+          "name": "disposal_requests_asset_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        },
+        "disposal_requests_status_idx": {
+          "name": "disposal_requests_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "disposal_requests_assetId_assets_id_fk": {
+          "name": "disposal_requests_assetId_assets_id_fk",
+          "tableFrom": "disposal_requests",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "disposal_requests_requestedBy_employees_id_fk": {
+          "name": "disposal_requests_requestedBy_employees_id_fk",
+          "tableFrom": "disposal_requests",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "disposal_requests_itApprovedBy_employees_id_fk": {
+          "name": "disposal_requests_itApprovedBy_employees_id_fk",
+          "tableFrom": "disposal_requests",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "itApprovedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "disposal_requests_financeApprovedBy_employees_id_fk": {
+          "name": "disposal_requests_financeApprovedBy_employees_id_fk",
+          "tableFrom": "disposal_requests",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "financeApprovedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "disposal_requests_rejectedBy_employees_id_fk": {
+          "name": "disposal_requests_rejectedBy_employees_id_fk",
+          "tableFrom": "disposal_requests",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "rejectedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "employee_notifications": {
+      "name": "employee_notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "employeeId": {
+          "name": "employeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'INFO'"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "emp_notif_employee_idx": {
+          "name": "emp_notif_employee_idx",
+          "columns": [
+            "employeeId"
+          ],
+          "isUnique": false
+        },
+        "emp_notif_read_idx": {
+          "name": "emp_notif_read_idx",
+          "columns": [
+            "employeeId",
+            "isRead"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "employee_notifications_employeeId_employees_id_fk": {
+          "name": "employee_notifications_employeeId_employees_id_fk",
+          "tableFrom": "employee_notifications",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "employees": {
+      "name": "employees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entraId": {
+          "name": "entraId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clerkId": {
+          "name": "clerkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'EMPLOYEE'"
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "firstNameEng": {
+          "name": "firstNameEng",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastNameEng": {
+          "name": "lastNameEng",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signUrl": {
+          "name": "signUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hireDate": {
+          "name": "hireDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "terminationDate": {
+          "name": "terminationDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'INACTIVE'"
+        },
+        "numberOfVacationDays": {
+          "name": "numberOfVacationDays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "employeeCode": {
+          "name": "employeeCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isKpi": {
+          "name": "isKpi",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "isSalaryCompany": {
+          "name": "isSalaryCompany",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "birthDayAndMonth": {
+          "name": "birthDayAndMonth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birthdayPoster": {
+          "name": "birthdayPoster",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "locations_parentId_locations_id_fk": {
+          "name": "locations_parentId_locations_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_tickets": {
+      "name": "maintenance_tickets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporterId": {
+          "name": "reporterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        },
+        "vendorId": {
+          "name": "vendorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repairCost": {
+          "name": "repairCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slaDeadline": {
+          "name": "slaDeadline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "maintenance_tickets_asset_idx": {
+          "name": "maintenance_tickets_asset_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        },
+        "maintenance_tickets_status_idx": {
+          "name": "maintenance_tickets_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "maintenance_tickets_sla_idx": {
+          "name": "maintenance_tickets_sla_idx",
+          "columns": [
+            "slaDeadline"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "maintenance_tickets_assetId_assets_id_fk": {
+          "name": "maintenance_tickets_assetId_assets_id_fk",
+          "tableFrom": "maintenance_tickets",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maintenance_tickets_reporterId_employees_id_fk": {
+          "name": "maintenance_tickets_reporterId_employees_id_fk",
+          "tableFrom": "maintenance_tickets",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "reporterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maintenance_tickets_vendorId_vendors_id_fk": {
+          "name": "maintenance_tickets_vendorId_vendors_id_fk",
+          "tableFrom": "maintenance_tickets",
+          "tableTo": "vendors",
+          "columnsFrom": [
+            "vendorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "employeeId": {
+          "name": "employeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'INFO'"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "notifications_employee_idx": {
+          "name": "notifications_employee_idx",
+          "columns": [
+            "employeeId"
+          ],
+          "isUnique": false
+        },
+        "notifications_role_idx": {
+          "name": "notifications_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        },
+        "notifications_read_idx": {
+          "name": "notifications_read_idx",
+          "columns": [
+            "isRead"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_employeeId_employees_id_fk": {
+          "name": "notifications_employeeId_employees_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "offboarding_events": {
+      "name": "offboarding_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "employeeId": {
+          "name": "employeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initiatedBy": {
+          "name": "initiatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'IN_PROGRESS'"
+        },
+        "totalAssets": {
+          "name": "totalAssets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "returnedAssets": {
+          "name": "returnedAssets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "assetIdsJson": {
+          "name": "assetIdsJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "offboarding_events_employee_id_idx": {
+          "name": "offboarding_events_employee_id_idx",
+          "columns": [
+            "employeeId"
+          ],
+          "isUnique": false
+        },
+        "offboarding_events_status_value_idx": {
+          "name": "offboarding_events_status_value_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "offboarding_events_employeeId_employees_id_fk": {
+          "name": "offboarding_events_employeeId_employees_id_fk",
+          "tableFrom": "offboarding_events",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "offboarding_events_initiatedBy_employees_id_fk": {
+          "name": "offboarding_events_initiatedBy_employees_id_fk",
+          "tableFrom": "offboarding_events",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "initiatedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "offboarding_return_requests": {
+      "name": "offboarding_return_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offboardingEventId": {
+          "name": "offboardingEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignmentId": {
+          "name": "assignmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "employeeId": {
+          "name": "employeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conditionEmployee": {
+          "name": "conditionEmployee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING_HR'"
+        },
+        "conditionHr": {
+          "name": "conditionHr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "photoR2Key": {
+          "name": "photoR2Key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspectedBy": {
+          "name": "inspectedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "offboarding_return_requests_event_idx": {
+          "name": "offboarding_return_requests_event_idx",
+          "columns": [
+            "offboardingEventId"
+          ],
+          "isUnique": false
+        },
+        "offboarding_return_requests_asset_idx": {
+          "name": "offboarding_return_requests_asset_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        },
+        "offboarding_return_requests_status_idx": {
+          "name": "offboarding_return_requests_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "offboarding_return_requests_offboardingEventId_offboarding_events_id_fk": {
+          "name": "offboarding_return_requests_offboardingEventId_offboarding_events_id_fk",
+          "tableFrom": "offboarding_return_requests",
+          "tableTo": "offboarding_events",
+          "columnsFrom": [
+            "offboardingEventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "offboarding_return_requests_assetId_assets_id_fk": {
+          "name": "offboarding_return_requests_assetId_assets_id_fk",
+          "tableFrom": "offboarding_return_requests",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "offboarding_return_requests_assignmentId_assignments_id_fk": {
+          "name": "offboarding_return_requests_assignmentId_assignments_id_fk",
+          "tableFrom": "offboarding_return_requests",
+          "tableTo": "assignments",
+          "columnsFrom": [
+            "assignmentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "offboarding_return_requests_employeeId_employees_id_fk": {
+          "name": "offboarding_return_requests_employeeId_employees_id_fk",
+          "tableFrom": "offboarding_return_requests",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "offboarding_return_requests_inspectedBy_employees_id_fk": {
+          "name": "offboarding_return_requests_inspectedBy_employees_id_fk",
+          "tableFrom": "offboarding_return_requests",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "inspectedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "purchase_order_items": {
+      "name": "purchase_order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchaseOrderId": {
+          "name": "purchaseOrderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unitCost": {
+          "name": "unitCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "totalCost": {
+          "name": "totalCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "purchase_order_items_order_idx": {
+          "name": "purchase_order_items_order_idx",
+          "columns": [
+            "purchaseOrderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "purchase_order_items_purchaseOrderId_purchase_orders_id_fk": {
+          "name": "purchase_order_items_purchaseOrderId_purchase_orders_id_fk",
+          "tableFrom": "purchase_order_items",
+          "tableTo": "purchase_orders",
+          "columnsFrom": [
+            "purchaseOrderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "purchase_order_items_categoryId_categories_id_fk": {
+          "name": "purchase_order_items_categoryId_categories_id_fk",
+          "tableFrom": "purchase_order_items",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "categoryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_order_items_modelId_asset_models_id_fk": {
+          "name": "purchase_order_items_modelId_asset_models_id_fk",
+          "tableFrom": "purchase_order_items",
+          "tableTo": "asset_models",
+          "columnsFrom": [
+            "modelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "purchase_orders": {
+      "name": "purchase_orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vendorId": {
+          "name": "vendorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approvedBy": {
+          "name": "approvedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totalCost": {
+          "name": "totalCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "purchase_orders_vendor_idx": {
+          "name": "purchase_orders_vendor_idx",
+          "columns": [
+            "vendorId"
+          ],
+          "isUnique": false
+        },
+        "purchase_orders_status_idx": {
+          "name": "purchase_orders_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "purchase_orders_vendorId_vendors_id_fk": {
+          "name": "purchase_orders_vendorId_vendors_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "vendors",
+          "columnsFrom": [
+            "vendorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_requestedBy_employees_id_fk": {
+          "name": "purchase_orders_requestedBy_employees_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_approvedBy_employees_id_fk": {
+          "name": "purchase_orders_approvedBy_employees_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "approvedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "purchase_requests": {
+      "name": "purchase_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assetTag": {
+          "name": "assetTag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "serialNumber": {
+          "name": "serialNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchaseCost": {
+          "name": "purchaseCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchaseDate": {
+          "name": "purchaseDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requesterEmployeeId": {
+          "name": "requesterEmployeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requesterEmail": {
+          "name": "requesterEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decidedAt": {
+          "name": "decidedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decidedBy": {
+          "name": "decidedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolvedAssetId": {
+          "name": "resolvedAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "purchase_requests_category_idx": {
+          "name": "purchase_requests_category_idx",
+          "columns": [
+            "categoryId"
+          ],
+          "isUnique": false
+        },
+        "purchase_requests_asset_idx": {
+          "name": "purchase_requests_asset_idx",
+          "columns": [
+            "resolvedAssetId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "purchase_requests_categoryId_categories_id_fk": {
+          "name": "purchase_requests_categoryId_categories_id_fk",
+          "tableFrom": "purchase_requests",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "categoryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_requests_modelId_asset_models_id_fk": {
+          "name": "purchase_requests_modelId_asset_models_id_fk",
+          "tableFrom": "purchase_requests",
+          "tableTo": "asset_models",
+          "columnsFrom": [
+            "modelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_requests_requesterEmployeeId_employees_id_fk": {
+          "name": "purchase_requests_requesterEmployeeId_employees_id_fk",
+          "tableFrom": "purchase_requests",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "requesterEmployeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_requests_decidedBy_employees_id_fk": {
+          "name": "purchase_requests_decidedBy_employees_id_fk",
+          "tableFrom": "purchase_requests",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "decidedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_requests_resolvedAssetId_assets_id_fk": {
+          "name": "purchase_requests_resolvedAssetId_assets_id_fk",
+          "tableFrom": "purchase_requests",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "resolvedAssetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_notification_reads": {
+      "name": "role_notification_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "employeeId": {
+          "name": "employeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "role_notif_reads_notif_idx": {
+          "name": "role_notif_reads_notif_idx",
+          "columns": [
+            "notificationId"
+          ],
+          "isUnique": false
+        },
+        "role_notif_reads_emp_idx": {
+          "name": "role_notif_reads_emp_idx",
+          "columns": [
+            "employeeId"
+          ],
+          "isUnique": false
+        },
+        "role_notif_reads_unique_idx": {
+          "name": "role_notif_reads_unique_idx",
+          "columns": [
+            "notificationId",
+            "employeeId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "role_notification_reads_notificationId_role_notifications_id_fk": {
+          "name": "role_notification_reads_notificationId_role_notifications_id_fk",
+          "tableFrom": "role_notification_reads",
+          "tableTo": "role_notifications",
+          "columnsFrom": [
+            "notificationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_notification_reads_employeeId_employees_id_fk": {
+          "name": "role_notification_reads_employeeId_employees_id_fk",
+          "tableFrom": "role_notification_reads",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_notifications": {
+      "name": "role_notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'INFO'"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "role_notif_role_idx": {
+          "name": "role_notif_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transfers": {
+      "name": "transfers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fromEmployeeId": {
+          "name": "fromEmployeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toEmployeeId": {
+          "name": "toEmployeeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approvedBy": {
+          "name": "approvedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conditionNoted": {
+          "name": "conditionNoted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transferredAt": {
+          "name": "transferredAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "transfers_asset_idx": {
+          "name": "transfers_asset_idx",
+          "columns": [
+            "assetId"
+          ],
+          "isUnique": false
+        },
+        "transfers_from_employee_idx": {
+          "name": "transfers_from_employee_idx",
+          "columns": [
+            "fromEmployeeId"
+          ],
+          "isUnique": false
+        },
+        "transfers_to_employee_idx": {
+          "name": "transfers_to_employee_idx",
+          "columns": [
+            "toEmployeeId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transfers_assetId_assets_id_fk": {
+          "name": "transfers_assetId_assets_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "assetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transfers_fromEmployeeId_employees_id_fk": {
+          "name": "transfers_fromEmployeeId_employees_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "fromEmployeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transfers_toEmployeeId_employees_id_fk": {
+          "name": "transfers_toEmployeeId_employees_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "toEmployeeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transfers_approvedBy_employees_id_fk": {
+          "name": "transfers_approvedBy_employees_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "approvedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vendors": {
+      "name": "vendors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contactName": {
+          "name": "contactName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/assets-management-backend/drizzle/meta/_journal.json
+++ b/assets-management-backend/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1780136889129,
+      "tag": "0000_init_schema",
+      "breakpoints": true
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Cursor Cloud development documentation and a missing baseline D1 migration.

## Changes

- **`AGENTS.md`**: Local dev notes (ports, `DISABLE_AUTH`, local vs remote Wrangler bindings, D1 init, GraphQL smoke test).
- **`drizzle/0000_init_schema.sql`**: Baseline schema migration generated from `schema.ts`. Fixes fresh local DB setup where only `0001_add_current_book_value.sql` existed (ALTER on non-existent `assets` table).

## Note

If `0001_add_current_book_value.sql` fails locally with "duplicate column", the init migration already includes `currentBookValue`; the local DB is still usable after `0000` applies.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d8cac11-3020-4f76-a70e-86abf7b4114e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d8cac11-3020-4f76-a70e-86abf7b4114e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

